### PR TITLE
按照不同的 device type redirect 到不同的 store

### DIFF
--- a/commandp/templates/default/nodejs_nginx.erb
+++ b/commandp/templates/default/nodejs_nginx.erb
@@ -60,6 +60,35 @@ server {
     set $mobile_rewrite perform;
   }
 
+  ##  ==== redirect apple store or google store by device type at commandp.com/mobile =====
+  if ($http_user_agent ~* "(iPhone|iPod)") {
+    set $mobile_type ios;
+  }
+
+  if ($http_user_agent ~* "(Android)") {
+    set $mobile_type android;
+  }
+
+  if ($uri = "/download") {
+    set $mobile_type "${mobile_type}_download";
+  }
+
+  if ($mobile_type = ios_download) {
+    rewrite ^ https://itunes.apple.com/tw/app/wo-yin-ge-xing-hua-ying-xiang/id898632563?l=zh&mt=8 redirect;
+    break;
+  }
+
+  if ($mobile_type = android_download) {
+    rewrite ^ https://play.google.com/store/apps/details?id=com.commandp.me&hl=zh_TW redirect;
+    break;
+  }
+
+  if ($mobile_type = _download) {
+    rewrite ^ /mobile redirect;
+    break;
+  }
+  ## ==== end =====
+
   if ($uri ~* "/(search|mobile|sign_in|b2b|contact|faq|api)") {
     set $mobile_rewrite nil;
   }
@@ -210,6 +239,35 @@ server {
   if ($http_user_agent ~* "^(1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-)") {
     set $mobile_rewrite perform;
   }
+
+  ##  ==== redirect apple store or google store by device type at commandp.com/mobile =====
+  if ($http_user_agent ~* "(iPhone|iPod)") {
+    set $mobile_type ios;
+  }
+
+  if ($http_user_agent ~* "(Android)") {
+    set $mobile_type android;
+  }
+
+  if ($uri = "/download") {
+    set $mobile_type "${mobile_type}_download";
+  }
+
+  if ($mobile_type = ios_download) {
+    rewrite ^ https://itunes.apple.com/tw/app/wo-yin-ge-xing-hua-ying-xiang/id898632563?l=zh&mt=8 redirect;
+    break;
+  }
+
+  if ($mobile_type = android_download) {
+    rewrite ^ https://play.google.com/store/apps/details?id=com.commandp.me&hl=zh_TW redirect;
+    break;
+  }
+
+  if ($mobile_type = _download) {
+    rewrite ^ /mobile redirect;
+    break;
+  }
+  ## ==== end =====
 
   if ($uri ~* "/(search|mobile|sign_in|b2b|contact|faq|api)") {
     set $mobile_rewrite nil;


### PR DESCRIPTION
當使用者訪問 https://commandp.com/download 時，判斷 user agent 是 iOS 時 redirect to ios app link, 如果是 android 則 redirect to android download link, 如果都不是則 redirect to https://commandp.com/mobile
## 下載連結：

安卓 app：https://play.google.com/store/apps/details?id=com.commandp.me&hl=zh_TW
iOS app：https://itunes.apple.com/tw/app/wo-yin-ge-xing-hua-ying-xiang/id898632563?l=zh&mt=8
## Redmine 票的URL

https://ticket.commandp.com/issues/1020
