### PR TITLE
新增 proxy_set_header X-Forwarded-Proto https 到 nginx

### DIFF
--- a/unicorn/templates/default/nginx_unicorn_web_app.erb
+++ b/unicorn/templates/default/nginx_unicorn_web_app.erb
@@ -269,6 +269,7 @@ server {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-NginX-Proxy true;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
     proxy_redirect off;
 
 


### PR DESCRIPTION
新增這個，否則 Rails 有 force_ssl 的關係，沒帶到 https 的話，會一直 redirect 

```
proxy_set_header X-Forwarded-Proto https;
```
