### PR TITLE
加入 Zabbix 監控特定 process 的 memory 使用量 module

### DIFF
--- a/commandp/files/default/zabbix/memory-check.sh
+++ b/commandp/files/default/zabbix/memory-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# ============================================================
+#  Author: Jonny Lai / jonny.lai (at) commandp.com
+#  Filename: memory-check.sh
+#  Modified: 2016-10-24 15:47
+#  Description: Monitoring process memory usage.
+#
+#   `ps aux` 結果中的 RSS (resident set size) 的單位是 KB，而 zabbix-
+#   server 用的單位是 B，所以得多乘以 1024 才符合真實情況。
+#
+#  Reference:
+#
+#   1. linux - ps aux output meaning | Super User
+#    - http://superuser.com/a/117921/205255
+#
+# ===========================================================
+
+PROCESS_NAME="$1"
+ps aux | grep $PROCESS_NAME | awk '{ sum=sum+$6 }; END { print sum*1024 }'
+

--- a/commandp/files/default/zabbix/zabbix_agentd_memory.conf
+++ b/commandp/files/default/zabbix/zabbix_agentd_memory.conf
@@ -1,0 +1,9 @@
+# ============================================================
+#  Author: Jonny / jonny.lai (at) commandp.com
+#  Filename: zabbix_agentd_memory_sum.conf
+#  Modified: 2016-10-12 15:15
+#  Description: Custom UserParameter for monitoring process memory usage.
+# ===========================================================
+
+UserParameter=memory_sum[*],/etc/zabbix/bin/memory-check.sh "$1"
+

--- a/commandp/metadata.rb
+++ b/commandp/metadata.rb
@@ -5,3 +5,4 @@ description      "Configures commandp app server environment."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.0"
 depends          "aws"
+depends          "zabbix-agent", ">= 0.14.2"

--- a/commandp/metadata.rb
+++ b/commandp/metadata.rb
@@ -5,4 +5,4 @@ description      "Configures commandp app server environment."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.0"
 depends          "aws"
-depends          "zabbix-agent", ">= 0.14.2"
+depends          "zabbix-agent", ">= 0.14.3"

--- a/commandp/recipes/zabbix_agent.rb
+++ b/commandp/recipes/zabbix_agent.rb
@@ -1,0 +1,38 @@
+# ============================================================
+#  Author: Jonny / jonny.lai (at) commandp.com
+#  Filename: zabbix_monitoring_nginx.rb
+#  Modified: 2016-10-03 19:05
+#  Description: Deploy nginx status module of Zabbix.
+#  Reference: 
+#
+#   1. Zabbix 监控 nginx 性能 (113) | 运维生存时间
+#     - http://www.ttlsa.com/zabbix/zabbix-monitor-nginx-performance/
+#
+# =========================================================== 
+
+# use the Third-party cookbook.
+include_recipe 'zabbix-agent'
+
+# Custom.
+log 'custom zabbix-agent environment.'
+
+# - Delete file.
+file '/etc/zabbix/zabbix_agentd.d/userparameter_mysql.conf' do
+  action :delete
+end
+
+# - Delete directorys.
+['/etc/zabbix/zabbix_agentd.d', '/etc/zabbix/scripts'].each do |dir|
+  directory dir do
+    action :delete
+  end
+end
+
+# - Create directory.
+directory '/etc/zabbix/zabbix_agentd.conf.d' do
+  action :create
+end
+
+# include other recipe.
+include_recipe 'commandp::zabbix_agent_memory_usage'
+

--- a/commandp/recipes/zabbix_agent_memory_usage.rb
+++ b/commandp/recipes/zabbix_agent_memory_usage.rb
@@ -1,0 +1,40 @@
+# ============================================================
+#  Author: Jonny / jonny.lai (at) commandp.com
+#  Cookbook Name: cp-zabbix-agent
+#  Description: Deploy memory usage module of Zabbix.
+#  Filename: memory_usage.rb
+#  Modified: 2016-10-24 16:34
+#  Recipe: nginx_status
+#  Reference:
+#
+#   1. - Total memory used by Python process? | Stack Overflow
+#    - http://stackoverflow.com/a/40173829/686105
+#
+# ===========================================================
+
+# load commandp::zabbix-agent recipe."
+include_recipe 'commandp::zabbix-agent'
+
+# Create directory for 'nginx-check.sh'.
+directory '/etc/zabbix/bin' do
+  mode '0755'
+  action :create
+end
+
+# Put nginx-check.sh to `/etc/zabbix/bin/`.
+cookbook_file '/etc/zabbix/bin/memory-check.sh' do
+  source 'zabbix/memory-check.sh'
+  mode 0755
+end
+
+# Put nginx.conf to `/etc/zabbix/zabbix_agentd.conf.d`.
+cookbook_file '/etc/zabbix/zabbix_agentd.conf.d/memory.conf' do
+  source 'zabbix/zabbix_agentd_memory.conf'
+  mode 0644
+end
+
+# restart service.
+service "zabbix-agent" do
+  supports :restart => true, :status => true
+  action :restart
+end

--- a/commandp/recipes/zabbix_agent_memory_usage.rb
+++ b/commandp/recipes/zabbix_agent_memory_usage.rb
@@ -13,7 +13,7 @@
 # ===========================================================
 
 # load commandp::zabbix-agent recipe."
-include_recipe 'commandp::zabbix-agent'
+include_recipe 'commandp::zabbix_agent'
 
 # Create directory for 'nginx-check.sh'.
 directory '/etc/zabbix/bin' do

--- a/commandp/recipes/zabbix_agent_nginx_status.rb
+++ b/commandp/recipes/zabbix_agent_nginx_status.rb
@@ -11,7 +11,7 @@
 # =========================================================== 
 
 # load commandp::zabbix-agent recipe."
-include_recipe 'commandp::zabbix-agent'
+include_recipe 'commandp::zabbix_agent'
 
 # Install necessary package.
 package 'Install wget' do

--- a/commandp/recipes/zabbix_agent_nginx_status.rb
+++ b/commandp/recipes/zabbix_agent_nginx_status.rb
@@ -10,6 +10,9 @@
 #
 # =========================================================== 
 
+# load commandp::zabbix-agent recipe."
+include_recipe 'commandp::zabbix-agent'
+
 # Install necessary package.
 package 'Install wget' do
   package_name 'wget'


### PR DESCRIPTION
#### PR 的目的?
1. 重構 include `zabbix-agent` 的 recipe：從成先手動 include `zabbix-agent` 變成 `commandp::zabbix_agent` 幫我 include。
2. 加入**Zabbix 監控特定 process 的 memory 使用量** module。
#### 其他:
- 詳情請看 #996 issue。
#### TODO:
- [x] 在 Staging 測過了嗎？
- [x] 把 Staging 的 Revision 切回 master 了嗎？
